### PR TITLE
Dashboard interviews page FE

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1404,6 +1404,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "axios": "^0.21.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -64,6 +64,7 @@ function App() {
               <PrivateRoute exact path='/faq' component={Faq} />
             </StateProvider>
           </Switch>
+          <PrivateRoute path='/' component={Signup} />
         </Switch>
       </MuiThemeProvider>
     </Router>

--- a/client/src/Components/PastInterviewTable.js
+++ b/client/src/Components/PastInterviewTable.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+import { useStyles } from '../themes/theme'
+
+function createPastInterviewData(name, codingRating, communcationRating, questions, detailedFeedback) {
+  return { name, codingRating, communcationRating, questions, detailedFeedback };
+}
+
+const pastInterviews = [
+  createPastInterviewData({ date: "Thursday, Apr 30, 2020", time: "10:00 AM - 11:00 AM" }, 4.5, 4.0, "View", "View"),
+  createPastInterviewData({ date: "Wednesday, Mar 18, 2020", time: "2:00 PM - 3:30 PM" }, 3.0, 4.5, "View", "View"),
+];
+
+const PastInterviewTable = () => {
+  const classes = useStyles();
+
+  return (
+    <TableContainer>
+      <Table className={classes.interviewTable} aria-label="simple table">
+        <TableHead className={classes.interviewTableHeader}>
+          <TableRow>
+            <TableCell className={classes.headerFont}>Held&nbsp;on</TableCell>
+            <TableCell className={classes.headerFont} align="right">Coding</TableCell>
+            <TableCell className={classes.headerFont} align="right">Communication</TableCell>
+            <TableCell className={classes.headerFont} align="right">Questions</TableCell>
+            <TableCell className={classes.headerFont} align="right">Detailed&nbsp;feedback</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {pastInterviews.map((interview) => (
+            <TableRow key={interview.name}>
+              <TableCell component="th" scope="row">
+                <div>
+                  {interview.name.date}
+                </div>
+                <div>
+                  {interview.name.time}
+                </div>
+              </TableCell>
+              <TableCell align="right">{interview.codingRating}</TableCell>
+              <TableCell align="right">{interview.communcationRating}</TableCell>
+              <TableCell align="right">{interview.questions}</TableCell>
+              <TableCell align="right">{interview.detailedFeedback}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+export default PastInterviewTable

--- a/client/src/Components/PastInterviewTable.js
+++ b/client/src/Components/PastInterviewTable.js
@@ -1,24 +1,24 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
 import { useStyles } from '../themes/theme'
-
-function createPastInterviewData(name, codingRating, communcationRating, questions, detailedFeedback) {
-  return { name, codingRating, communcationRating, questions, detailedFeedback };
-}
-
-const pastInterviews = [
-  createPastInterviewData({ date: "Thursday, Apr 30, 2020", time: "10:00 AM - 11:00 AM" }, 4.5, 4.0, "View", "View"),
-  createPastInterviewData({ date: "Wednesday, Mar 18, 2020", time: "2:00 PM - 3:30 PM" }, 3.0, 4.5, "View", "View"),
-];
+import Rating from '@material-ui/lab/Rating';
 
 const PastInterviewTable = () => {
+
+  const createPastInterviewData = (name, codingRating, communcationRating, questions, detailedFeedback) => {
+    return { name, codingRating, communcationRating, questions, detailedFeedback };
+  }
+
+  const pastInterviews = [
+    createPastInterviewData({ date: "Thursday, Apr 30, 2020", time: "10:00 AM - 11:00 AM" }, 4.5, 4.0, "View", "View"),
+    createPastInterviewData({ date: "Wednesday, Mar 18, 2020", time: "2:00 PM - 3:30 PM" }, 3.0, 4.5, "View", "View"),
+  ];
+
   const classes = useStyles();
 
   return (
@@ -44,8 +44,12 @@ const PastInterviewTable = () => {
                   {interview.name.time}
                 </div>
               </TableCell>
-              <TableCell align="right">{interview.codingRating}</TableCell>
-              <TableCell align="right">{interview.communcationRating}</TableCell>
+              <TableCell align="right">
+                <Rating name="read-only" value={interview.codingRating} readOnly />
+              </TableCell>
+              <TableCell align="right">
+                <Rating name="read-only" value={interview.communcationRating} readOnly />
+              </TableCell>
               <TableCell align="right">{interview.questions}</TableCell>
               <TableCell align="right">{interview.detailedFeedback}</TableCell>
             </TableRow>

--- a/client/src/components/Buttons.js
+++ b/client/src/components/Buttons.js
@@ -23,3 +23,16 @@ export const RedirectPageButton = withStyles({
     marginLeft: '10px'
   },
 })(Button);
+
+export const StartDashboardButton = withStyles({
+  root: {
+    borderRadius: 35,
+    height: 40,
+    width: 100,
+    backgroundColor: colors.darkBlue,
+    padding: "18px 36px",
+    fontSize: "18px",
+    color: 'white',
+    marginTop: '30px'
+  },
+})(Button);

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useContext } from 'react';
 import { useStyles } from '../themes/theme';
-import Button from '@material-ui/core/Button'
 import { StartDashboardButton } from '../components/Buttons'
+import PastInterviewTable from '../components/PastInterviewTable'
 
 import { store } from '../context/store';
 
@@ -18,7 +18,7 @@ const DashBoard = (props) => {
     <div className={classes.dashboardContainer}>
       <StartDashboardButton>START</StartDashboardButton>
       <p className={classes.pastPracticesText}>Past Practice Interviews</p>
-      Bottom
+      <PastInterviewTable />
     </div>
   );
 >>>>>>> Justify content to center from top to bottom

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -16,11 +16,9 @@ const DashBoard = (props) => {
 
   return (
     <div className={classes.dashboardContainer}>
-      <div>
-        <StartDashboardButton>START</StartDashboardButton>
-      </div>
-      <div>Middle</div>
-      <div>Bottom</div>
+      <StartDashboardButton>START</StartDashboardButton>
+      <p className={classes.pastPracticesText}>Past Practice Interviews</p>
+      Bottom
     </div>
   );
 >>>>>>> Justify content to center from top to bottom

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -8,10 +8,6 @@ import { store } from '../context/store';
 
 const DashBoard = (props) => {
   const { state } = useContext(store);
-<<<<<<< HEAD
-
-  return <div>Hello from dashboard {state.user.email}</div>;
-=======
   const classes = useStyles()
 
   return (
@@ -21,7 +17,6 @@ const DashBoard = (props) => {
       <PastInterviewTable />
     </div>
   );
->>>>>>> Justify content to center from top to bottom
 };
 
 export default DashBoard;

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useContext } from 'react';
 import { useStyles } from '../themes/theme';
+import Button from '@material-ui/core/Button'
+import { StartDashboardButton } from '../components/Buttons'
 
 import { store } from '../context/store';
 
@@ -14,7 +16,9 @@ const DashBoard = (props) => {
 
   return (
     <div className={classes.dashboardContainer}>
-      <div>Top</div>
+      <div>
+        <StartDashboardButton>START</StartDashboardButton>
+      </div>
       <div>Middle</div>
       <div>Bottom</div>
     </div>

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -1,12 +1,25 @@
 import React from 'react';
 import { useContext } from 'react';
+import { useStyles } from '../themes/theme';
 
 import { store } from '../context/store';
 
 const DashBoard = (props) => {
   const { state } = useContext(store);
+<<<<<<< HEAD
 
   return <div>Hello from dashboard {state.user.email}</div>;
+=======
+  const classes = useStyles()
+
+  return (
+    <div className={classes.dashboardContainer}>
+      <div>Top</div>
+      <div>Middle</div>
+      <div>Bottom</div>
+    </div>
+  );
+>>>>>>> Justify content to center from top to bottom
 };
 
 export default DashBoard;

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -72,6 +72,12 @@ export const useStyles = makeStyles((theme) => ({
     justifyContent: 'center',
     alignContent: 'center',
     flexDirection: 'column'
+  },
+  dashboardContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
   }
 }))
 

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -82,7 +82,21 @@ export const useStyles = makeStyles((theme) => ({
   pastPracticesText: {
     fontSize: '40px',
     color: colors.darkBlue
-  }
+  },
+  interviewTable: {
+    width: 1000,
+    margin: 'auto',
+    borderWidth: 1,
+    borderColor: 'black',
+  },
+  interviewTableHeader: {
+    backgroundColor: colors.darkBlue,
+  },
+  headerFont: {
+    color: 'white',
+    fontSize: 15,
+    fontWeight: 'bold'
+  },
 }))
 
 export const colors = {

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -78,6 +78,10 @@ export const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  pastPracticesText: {
+    fontSize: '40px',
+    color: colors.darkBlue
   }
 }))
 


### PR DESCRIPTION
Hey guys, I created the dashboard interviews FE page that displays a table of past interviews. I created a function that creates rows of past interviews with some sample data for now. Once I get the backend routes to work, we can show the user's actual past interviews in the table. 

![image](https://user-images.githubusercontent.com/61174647/99089990-055c6800-259c-11eb-93ff-9be2cda58243.png)

The reason I wanted to push the code right now was because our current repo doesn't have the logic for falling back to the signup page when the user is signed out. I will work on the BE routes for getting all user interviews now on a separate branch. 
