### PR TITLE
Use local storage to direct login/signup and dashboard routes

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,1 +1,2 @@
 SKIP_PREFLIGHT_CHECK=true
+REACT_APP_USER_DATA="allbran_userAuth_data"

--- a/client/src/Components/Navbar.js
+++ b/client/src/Components/Navbar.js
@@ -58,6 +58,7 @@ const Navbar = () => {
     history.push(route);
     if (route === '/signup') {
       dispatch({ type: LOGOUT });
+      localStorage.clear()
     }
   };
 

--- a/client/src/components/LoginForm.js
+++ b/client/src/components/LoginForm.js
@@ -65,6 +65,8 @@ const LoginForm = () => {
       let result = await axios.post('http://localhost:3001/users/login', formData)
       dispatch({ type: USER_LOADED, payload: result.data.user })
       history.push('/dashboard')
+      const res = JSON.stringify(result.data.user)
+      localStorage.setItem(process.env.REACT_APP_USER_DATA, res)
     }
     catch (error) {
       showAlert({ message: 'Invalid credentials!' });

--- a/client/src/components/LoginSignupWrapper.js
+++ b/client/src/components/LoginSignupWrapper.js
@@ -1,11 +1,33 @@
-import React from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import * as imageURL from '../images/login-photo.png';
 import Grid from '@material-ui/core/Grid';
 import { useStyles } from '../themes/theme';
+import { Link, useHistory } from 'react-router-dom';
+import { store } from '../context/store';
+import { USER_LOADED } from '../context/types';
 
 const LoginSignupWrapper = ({ children }) => {
+  const history = useHistory();
   const classes = useStyles();
+  const { dispatch } = useContext(store);
 
+  const userIsLoggedIn = () => {
+    return localStorage.getItem(process.env.REACT_APP_USER_DATA) !== null
+  }
+
+  const redirectToDashBoard = () => {
+    const res = JSON.parse(localStorage.getItem(process.env.REACT_APP_USER_DATA))
+    dispatch({
+      type: USER_LOADED,
+      payload: res,
+    });
+    history.push('/dashboard')
+  }
+  useEffect(() => {
+    if (userIsLoggedIn()) {
+      redirectToDashBoard()
+    }
+  }, [])
   return (
     <div className={classes.loginSignupWrapperRoot}>
       <Grid container spacing={2}>

--- a/client/src/components/SignupForm.js
+++ b/client/src/components/SignupForm.js
@@ -59,6 +59,8 @@ const SignupForm = () => {
       let result = await axios.post('http://localhost:3001/users/register', formData)
       dispatch({ type: USER_LOADED, payload: result.data.user })
       history.push('/dashboard')
+      const res = JSON.stringify(result.data.user)
+      localStorage.setItem(process.env.REACT_APP_USER_DATA, res)
     }
     catch (error) {
       console.log(error)


### PR DESCRIPTION
Hey guys, the branch says using cookies but I decided to use local storage to route pages based on if user refreshes the page while logged in or out. If the user is logged in, going to login or sign up will redirect the user back to the dashboard. I also used an environment variable for the local storage key which can be seen below. This should close out the login/signup integration ticket. 

<img width="361" alt="Screen Shot 2020-11-14 at 6 34 54 PM" src="https://user-images.githubusercontent.com/61174647/99159155-17c3c800-26a8-11eb-83ec-a1712e317cbc.png">
