### PR TITLE
Create interview page skeleton

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,2 +1,0 @@
-SKIP_PREFLIGHT_CHECK=true
-REACT_APP_USER_DATA="allbran_userAuth_data"

--- a/client/src/pages/Interview.js
+++ b/client/src/pages/Interview.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useStyles } from '../themes/theme';
+import Grid from '@material-ui/core/Grid';
+
+const Interview = () => {
+  const classes = useStyles();
+  return (
+    <div className={classes.interviewContainer}>
+      <Grid container spacing={3}>
+        <Grid className={classes.interviewHeader} item xs={12}>
+          <div className={classes.textMarginLeft}>Interview with</div>
+          <div className={classes.textMarginRight}>End Interview</div>
+        </Grid>
+        <Grid className={classes.interviewDetails} item xs={4}>
+          <div className={classes.textMarginLeft}>Question Details</div>
+        </Grid>
+        <Grid className={classes.interviewTextEditor} item xs={8}>
+          <div>Text Editor</div>
+          <div className={classes.interviewOutput}>
+            <div className={classes.interviewOutputHeader}>
+              <div className={classes.textMarginLeft}>Console</div>
+              <div className={classes.textMarginRight}>RUN CODE</div>
+            </div>
+          </div>
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export default Interview;

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -129,6 +129,53 @@ export const useStyles = makeStyles((theme) => ({
     color: `${colors.darkGray}`,
     marginBottom: '30px',
   },
+  interviewContainer: {
+    overflow: 'hidden',
+    height: '100vh',
+    width: '100vw',
+    position: 'relative'
+  },
+  interviewHeader: {
+    backgroundColor: colors.darkBlue,
+    display: 'flex',
+    justifyContent: 'space-between',
+    flexDirection: 'row',
+    height: '85px',
+    alignItems: 'center'
+  },
+  interviewDetails: {
+    height: '100vh'
+  },
+  interviewTextEditor: {
+    backgroundColor: 'rgba(30,30,30, 1)',
+    height: '100vh'
+  },
+  interviewOutput: {
+    backgroundColor: 'yellow',
+    bottom: '0',
+    position: 'absolute',
+    height: '15vh',
+    width: '66%',
+    marginBottom: '25px',
+    borderRadius: '25px'
+  },
+  interviewOutputHeader: {
+    backgroundColor: 'gray',
+    width: '100%',
+    borderTopLeftRadius: '25px',
+    borderTopRightRadius: '25px',
+    height: '25%',
+    display: 'flex',
+    justifyContent: 'space-between',
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  textMarginRight: {
+    marginRight: '10px'
+  },
+  textMarginLeft: {
+    marginLeft: '10px'
+  },
 }));
 
 export const colors = {


### PR DESCRIPTION
Hey guys, this is the main skeleton for the interview page. I created it using Material UI's grid system. It displays the header at the top, interview details on the left, and the text editor/output console on the right. The colors used are just to outline the divs and will be changed for the finished product.

<img width="1792" alt="Screen Shot 2020-11-16 at 3 16 03 PM" src="https://user-images.githubusercontent.com/61174647/99303497-04873880-281f-11eb-9d22-44819605578e.png">
