### PR TITLE
Implement text editor

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1521,6 +1521,15 @@
         "react-is": "^16.8.0"
       }
     },
+    "@monaco-editor/react": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-3.7.0.tgz",
+      "integrity": "sha512-Os/LLdEaoA1kBl0Cr3ssynmrpXpxh0Ddda6I/EHqfRETXUkv4A1YCTxWoF3MdodBrHWKguZIhVHR0tPFE1CswA==",
+      "requires": {
+        "@babel/runtime": "^7.11.0",
+        "state-local": "^1.0.1"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -12357,6 +12366,11 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         }
       }
+    },
+    "state-local": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.4.tgz",
+      "integrity": "sha512-ea0qFgZAlqjuwyUnIEST/sDxKhbW3CEcZJVR6ay3hCCXFPDfONsXjslPjHzhhtM/PFlIv0FTpteg3H5wFTNDyw=="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
+    "@monaco-editor/react": "^3.7.0",
     "axios": "^0.21.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/client/src/Components/InterviewQuestionDetails.js
+++ b/client/src/Components/InterviewQuestionDetails.js
@@ -15,10 +15,10 @@ const InterviewQuestionDetails = (props) => {
     <div className={classes.interviewDetailsContainer}>
       <div className={classes.questionAnswerButtonContainer}>
         <div onClick={() => setQuestionAnswerToggle({ answer: true, question: false })}>
-          <InterviewDetailButton questionAnswerToggle={answer} text="Answer" />
+          <InterviewDetailButton questionAnswerToggle={answer} text="Question" />
         </div>
         <div onClick={() => setQuestionAnswerToggle({ answer: false, question: true })}>
-          <InterviewDetailButton questionAnswerToggle={question} text="Question" />
+          <InterviewDetailButton questionAnswerToggle={question} text="Answer" />
         </div>
       </div>
       {answer

--- a/client/src/Components/TextEditor.js
+++ b/client/src/Components/TextEditor.js
@@ -1,8 +1,29 @@
-import React from 'react'
-import Editor from '@monaco-editor/react';
-const TextEditor = () => {
+import React, { useRef, useState } from 'react'
+import { ControlledEditor } from '@monaco-editor/react';
+
+const TextEditor = (props) => {
+  const [isEditorReady, setIsEditorReady] = useState(false);
+  const codeText = useRef();
+
+  function handleEditorDidMount(_codeText) {
+    setIsEditorReady(true);
+    codeText.current = _codeText;
+  }
+
+  const handleCodeChange = () => {
+    props.handleCodeSnippetChange(codeText.current())
+  }
+
   return (
-    <Editor height="90vh" theme="dark" options={{ fontSize: 18 }} language="javascript" />
+    <ControlledEditor
+      height="90vh"
+      theme="dark"
+      options={{ fontSize: 18 }}
+      language="javascript"
+      value={"// write your code here"}
+      editorDidMount={handleEditorDidMount}
+      onChange={handleCodeChange} />
+
   )
 }
 

--- a/client/src/Components/TextEditor.js
+++ b/client/src/Components/TextEditor.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import Editor from '@monaco-editor/react';
+const TextEditor = () => {
+  return (
+    <Editor height="90vh" theme="dark" options={{ fontSize: 18 }} language="javascript" />
+  )
+}
+
+export default TextEditor

--- a/client/src/components/Buttons.js
+++ b/client/src/components/Buttons.js
@@ -68,3 +68,9 @@ export const InterviewDetailButton = (props) => {
     </Button>
   )
 }
+
+export const RunCodeButton = (props) => {
+  const classes = useStyles()
+  const { text } = props
+  return <Button variant="outlined" className={classes.runCodeButton}>{text}</Button>
+}

--- a/client/src/pages/Interview.js
+++ b/client/src/pages/Interview.js
@@ -3,11 +3,17 @@ import { useStyles } from '../themes/theme';
 import Grid from '@material-ui/core/Grid';
 import InterviewQuestionDetails from '../components/InterviewQuestionDetails'
 import TextEditor from '../components/TextEditor'
+import { RunCodeButton } from '../components/Buttons';
 
 const Interview = () => {
   const classes = useStyles();
 
   const [codeSnippet, setCodeSnippet] = useState('')
+  const [output, setOutput] = useState('')
+
+  const runCode = (output) => {
+    setOutput(output)
+  }
 
   const handleCodeSnippetChange = (codeSnippet) => {
     setCodeSnippet(codeSnippet)
@@ -27,8 +33,13 @@ const Interview = () => {
           <TextEditor handleCodeSnippetChange={handleCodeSnippetChange} />
           <div className={classes.interviewOutput}>
             <div className={classes.interviewOutputHeader}>
-              <div className={classes.textMarginLeft}>Console</div>
-              <div className={classes.textMarginRight}>RUN CODE</div>
+              <div className={classes.consoleText}>Console</div>
+              <div onClick={() => runCode('hello')}>
+                <RunCodeButton text="RUN CODE" />
+              </div>
+            </div>
+            <div className={classes.outputText}>
+              {output}
             </div>
           </div>
         </Grid>

--- a/client/src/pages/Interview.js
+++ b/client/src/pages/Interview.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useStyles } from '../themes/theme';
 import Grid from '@material-ui/core/Grid';
 import InterviewQuestionDetails from '../components/InterviewQuestionDetails'
@@ -6,6 +6,13 @@ import TextEditor from '../components/TextEditor'
 
 const Interview = () => {
   const classes = useStyles();
+
+  const [codeSnippet, setCodeSnippet] = useState('')
+
+  const handleCodeSnippetChange = (codeSnippet) => {
+    setCodeSnippet(codeSnippet)
+  }
+
   return (
     <div className={classes.interviewContainer}>
       <Grid container spacing={3}>
@@ -17,7 +24,7 @@ const Interview = () => {
           <InterviewQuestionDetails />
         </Grid>
         <Grid className={classes.interviewTextEditor} item xs={8}>
-          <TextEditor />
+          <TextEditor handleCodeSnippetChange={handleCodeSnippetChange} />
           <div className={classes.interviewOutput}>
             <div className={classes.interviewOutputHeader}>
               <div className={classes.textMarginLeft}>Console</div>

--- a/client/src/pages/Interview.js
+++ b/client/src/pages/Interview.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useStyles } from '../themes/theme';
 import Grid from '@material-ui/core/Grid';
 import InterviewQuestionDetails from '../components/InterviewQuestionDetails'
+import TextEditor from '../components/TextEditor'
 
 const Interview = () => {
   const classes = useStyles();
@@ -16,7 +17,7 @@ const Interview = () => {
           <InterviewQuestionDetails />
         </Grid>
         <Grid className={classes.interviewTextEditor} item xs={8}>
-          <div>Text Editor</div>
+          <TextEditor />
           <div className={classes.interviewOutput}>
             <div className={classes.interviewOutputHeader}>
               <div className={classes.textMarginLeft}>Console</div>

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -288,7 +288,8 @@ export const useStyles = makeStyles((theme) => ({
   },
   questionAnswerButtonContainer: {
     display: 'flex',
-    flexDirection: 'row'
+    flexDirection: 'row',
+    marginTop: '20px'
   },
   runCodeButton: {
     color: 'white',

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -186,20 +186,24 @@ export const useStyles = makeStyles((theme) => ({
     height: '100vh',
   },
   interviewOutput: {
-    backgroundColor: 'yellow',
+    backgroundColor: colors.darkGraySolid,
     bottom: '0',
     position: 'absolute',
-    height: '15vh',
+    height: '20vh',
     width: '66%',
     marginBottom: '25px',
+<<<<<<< HEAD
     borderRadius: '25px',
+=======
+    borderRadius: '10px'
+>>>>>>> Implement run code button and style console with CSS
   },
   interviewOutputHeader: {
-    backgroundColor: 'gray',
+    backgroundColor: colors.lightGraySolid,
     width: '100%',
-    borderTopLeftRadius: '25px',
-    borderTopRightRadius: '25px',
-    height: '25%',
+    borderTopLeftRadius: '10px',
+    borderTopRightRadius: '10px',
+    height: '30%',
     display: 'flex',
     justifyContent: 'space-between',
     flexDirection: 'row',
@@ -288,9 +292,31 @@ export const useStyles = makeStyles((theme) => ({
   },
   questionAnswerButtonContainer: {
     display: 'flex',
-    flexDirection: 'row',
+    flexDirection: 'row'
   },
-}))
+  runCodeButton: {
+    color: 'white',
+    borderColor: colors.lightGray,
+    borderRadius: 25,
+    marginRight: '10px',
+    fontWeight: 'bold',
+    fontSize: '18px',
+    borderWidth: 4,
+    padding: '2px 20px'
+  },
+  consoleText: {
+    color: 'white',
+    marginLeft: '20px',
+    fontSize: '25px'
+  },
+  outputText: {
+    color: 'white',
+    marginTop: '15px',
+    paddingLeft: '20px',
+    fontFamily: 'monospace',
+    fontSize: '18px',
+  }
+}));
 
 export const GlobalCss = withStyles({
   '@global': {
@@ -316,4 +342,6 @@ export const colors = {
   lightGray: 'rgba(169, 169, 169, .8)',
   shadow: 'rgba(125, 123, 135, .3)',
   charcoalGray: 'rgba(30,30,30, .8)',
-}
+  darkGraySolid: 'rgba(105, 105, 105, 1)',
+  lightGraySolid: 'rgba(76, 76, 76, 1)'
+};

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -192,11 +192,7 @@ export const useStyles = makeStyles((theme) => ({
     height: '20vh',
     width: '66%',
     marginBottom: '25px',
-<<<<<<< HEAD
-    borderRadius: '25px',
-=======
     borderRadius: '10px'
->>>>>>> Implement run code button and style console with CSS
   },
   interviewOutputHeader: {
     backgroundColor: colors.lightGraySolid,


### PR DESCRIPTION
Hey guys, I implemented the text editor and console (and fixed some minor issues with the details section). The text editor was used with the Monaco Text Editor library. The interview page has a codeSnippet state that will keep track of the text editor's value. I styled the console to look more appealing and have a runCode function. For now it'll display "hello", but this will be updated in the future once we receive the actual output from the backend. 

<img width="1182" alt="Screen Shot 2020-11-17 at 4 09 12 PM" src="https://user-images.githubusercontent.com/61174647/99452265-53050780-28f1-11eb-9b76-0079122adf61.png">
<img width="1179" alt="Screen Shot 2020-11-17 at 4 09 29 PM" src="https://user-images.githubusercontent.com/61174647/99452455-89db1d80-28f1-11eb-8b5e-c48269eeab64.png">
<img width="1183" alt="Screen Shot 2020-11-17 at 4 17 57 PM" src="https://user-images.githubusercontent.com/61174647/99452303-5dbf9c80-28f1-11eb-89ac-a0c2703b1746.png">

All together it looks like this: 
<img width="1788" alt="Screen Shot 2020-11-17 at 9 37 20 PM" src="https://user-images.githubusercontent.com/61174647/99475695-13541500-291d-11eb-91ef-b01988cae787.png">



