### PR TITLE
Add route for interview page to /interview

### DIFF
--- a/client/src/routing/Routes.js
+++ b/client/src/routing/Routes.js
@@ -8,6 +8,7 @@ import Profile from '../pages/Profile';
 import PrivateRoute from './PrivateRoute';
 import Signup from '../pages/Signup';
 import Lobby from '../pages/Lobby';
+import Interview from '../pages/Interview';
 
 const Routes = () => {
   return (
@@ -18,7 +19,8 @@ const Routes = () => {
         <PrivateRoute exact path='/dashboard' component={DashBoard} />
         <PrivateRoute exact path='/blog' component={Blog} />
         <PrivateRoute exact path='/faq' component={Faq} />
-        <PrivateRoute exact path='/lobby' component={Lobby} />{' '}
+        <PrivateRoute exact path='/lobby' component={Lobby} />
+        <PrivateRoute exact path='/interview' component={Interview} />
         {/* This route can change */}
         <Route path='/' component={Signup} />
       </Switch>


### PR DESCRIPTION
Hey guys, I created an interview page route. So far its located at /interview but I'd imagine we'll be changing that to /interview/:id in the future once we fully get the waiting room dialogue and socket all working