### PR TITLE
Refactor buttons as reusable components

### DIFF
--- a/client/src/components/Buttons.js
+++ b/client/src/components/Buttons.js
@@ -1,10 +1,10 @@
-import Button from '@material-ui/core/Button'
-import { withStyles } from '@material-ui/core/styles'
-import { colors } from '../themes/theme'
-import React from 'react'
-import { useStyles } from '../themes/theme'
+import Button from '@material-ui/core/Button';
+import { withStyles } from '@material-ui/core/styles';
+import { colors } from '../themes/theme';
+import React from 'react';
+import { useStyles } from '../themes/theme';
 
-export const ContinueButton = withStyles({
+export const CopyButton = withStyles({
   root: {
     background: colors.darkBlue,
     color: 'white',
@@ -14,30 +14,7 @@ export const ContinueButton = withStyles({
     marginLeft: '10px',
     borderRadius: 25,
   },
-})(Button)
-
-export const RedirectPageButton = withStyles({
-  root: {
-    color: colors.darkGray,
-    height: '5ch',
-    padding: '0 30px',
-    marginLeft: '10px',
-    borderRadius: 25,
-  },
-})(Button)
-
-export const StartDashboardButton = withStyles({
-  root: {
-    borderRadius: 35,
-    height: 40,
-    width: 100,
-    backgroundColor: colors.darkBlue,
-    padding: '18px 36px',
-    fontSize: '18px',
-    color: 'white',
-    marginTop: '30px',
-  },
-})(Button)
+})(Button);
 
 export const NextStepButton = withStyles({
   root: {
@@ -51,11 +28,11 @@ export const NextStepButton = withStyles({
     marginTop: 'auto',
     marginBottom: 'auto',
   },
-})(Button)
+})(Button);
 
 export const InterviewDetailButton = (props) => {
-  const classes = useStyles()
-  const { text, questionAnswerToggle } = props
+  const classes = useStyles();
+  const { text, questionAnswerToggle } = props;
   return (
     <Button
       className={
@@ -67,22 +44,8 @@ export const InterviewDetailButton = (props) => {
       {text}
     </Button>
   )
-}
+};
 
-export const RunCodeButton = (props) => {
-  const classes = useStyles()
-  const { text } = props
-  return <Button variant="outlined" className={classes.runCodeButton}>{text}</Button>
-}
-
-export const ExitInterviewButton = (props) => {
-  const classes = useStyles()
-  const { text } = props
-  return <Button variant="outlined" className={classes.exitInterviewButton}>{text}</Button>
-}
-
-export const AnswerButton = (props) => {
-  const classes = useStyles()
-  const { text } = props
-  return <Button variant="outlined" className={classes.answerButton}>{text}</Button>
-}
+export const CustomButton = ({ classField, text, onClick }) => {
+  return <Button variant="outlined" className={classField} onClick={onClick}>{text}</Button>
+};

--- a/client/src/components/InterviewHeader.js
+++ b/client/src/components/InterviewHeader.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useStyles } from '../themes/theme';
 import Grid from '@material-ui/core/Grid';
 import LanguageSelectMenu from './LanguageSelectMenu';
-import { ExitInterviewButton } from '../components/Buttons';
+import { CustomButton } from '../components/Buttons';
 import { useHistory } from 'react-router-dom';
 
 const InterviewHeader = ({ language, setLanguage }) => {
@@ -22,9 +22,7 @@ const InterviewHeader = ({ language, setLanguage }) => {
       <div className={classes.interviewWithText}>Interview with </div>
       <div className={classes.languageExitInterviewContainer}>
         <LanguageSelectMenu handleLanguageChange={handleLanguageChange} language={language} />
-        <div onClick={exitInterview}>
-          <ExitInterviewButton text="End Interview" />
-        </div>
+        <CustomButton onClick={exitInterview} classField={classes.exitInterviewButton} text="End Interview" />
       </div>
     </Grid>
   );

--- a/client/src/components/InterviewQuestionDetails.js
+++ b/client/src/components/InterviewQuestionDetails.js
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
-import { InterviewDetailButton } from '../components/Buttons'
 import { useStyles } from '../themes/theme';
-import { AnswerButton } from './Buttons'
+import { CustomButton, InterviewDetailButton } from './Buttons'
 import { generateKey } from '../utils/generateRandomKey'
 
 const InterviewQuestionDetails = ({ questions }) => {
@@ -75,9 +74,10 @@ const InterviewQuestionDetails = ({ questions }) => {
         <p className={classes.questionTopicText}>{questionSet[questionDisplayed].title}</p>
         {parsedQuestionDescription(questionSet[questionDisplayed])}
         <div className={classes.answerButtonContainer}>
-          <div onClick={() => window.open(`${questionSet[questionDisplayed].url}/discuss`, "_blank")}>
-            <AnswerButton text="View Answer" />
-          </div>
+          <CustomButton
+            onClick={() => window.open(`${questionSet[questionDisplayed].url}/discuss`, "_blank")}
+            classField={classes.answerButton} text="View Answer"
+          />
         </div>
       </div>
     </div>

--- a/client/src/components/LoginForm.js
+++ b/client/src/components/LoginForm.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import TextField from '@material-ui/core/TextField';
 import { Link, useHistory } from 'react-router-dom';
-import { RedirectPageButton, ContinueButton } from '../components/Buttons';
+import { CustomButton } from '../components/Buttons';
 import { useStyles } from '../themes/theme';
 import axios from 'axios';
 import { store } from '../context/store';
@@ -65,9 +65,7 @@ const LoginForm = () => {
         <div className={classes.loginContainer}>
           <div className={classes.alreadyHaveAccount}>Don't have an account?</div>
           <Link style={{ textDecoration: 'none' }} to={{ pathname: '/signup' }}>
-            <RedirectPageButton variant='outlined' size='small'>
-              SIGN UP
-           </RedirectPageButton>
+            <CustomButton classField={classes.redirectPageButton} text='SIGN UP' />
           </Link>
         </div>
         <div>
@@ -94,7 +92,7 @@ const LoginForm = () => {
               value={formData.password}
               onChange={onChange}
             />
-            <ContinueButton onClick={onSubmit}>Continue</ContinueButton>
+            <CustomButton onClick={onSubmit} classField={classes.continueButton} text="Continue" />
           </form>
         </div>
       </div>

--- a/client/src/components/OutputConsole.js
+++ b/client/src/components/OutputConsole.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RunCodeButton } from './Buttons';
+import { CustomButton } from './Buttons';
 import { useStyles } from '../themes/theme';
 
 const OutputConsole = (props) => {
@@ -9,9 +9,7 @@ const OutputConsole = (props) => {
     <div className={classes.interviewOutput}>
       <div className={classes.interviewOutputHeader}>
         <div className={classes.consoleText}>Console</div>
-        <div onClick={props.runCode}>
-          <RunCodeButton text='RUN CODE' />
-        </div>
+        <CustomButton onClick={props.runCode} classField={classes.runCodeButton} text='RUN CODE' />
       </div>
       <div className={classes.outputText}>
         <pre>{props.codeResult}</pre>

--- a/client/src/components/SignupForm.js
+++ b/client/src/components/SignupForm.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import TextField from '@material-ui/core/TextField';
 import { Link, useHistory } from 'react-router-dom';
-import { RedirectPageButton, ContinueButton } from '../components/Buttons';
+import { CustomButton } from '../components/Buttons';
 import { useStyles } from '../themes/theme';
 import Snackbar from '@material-ui/core/Snackbar';
 import SnackbarContent from '@material-ui/core/SnackbarContent';
@@ -128,9 +128,7 @@ const SignupForm = () => {
       <div className={classes.loginContainer}>
         <div className={classes.alreadyHaveAccount}>Already have an account?</div>
         <Link style={{ textDecoration: 'none' }} to={{ pathname: '/login' }}>
-          <RedirectPageButton variant='outlined' size='small'>
-            Sign in
-          </RedirectPageButton>
+          <CustomButton classField={classes.redirectPageButton} text='SIGN IN' />
         </Link>
       </div>
       <div>
@@ -188,7 +186,7 @@ const SignupForm = () => {
             onChange={onChange}
             color='primary'
           />
-          <ContinueButton onClick={continueClicked}>Continue</ContinueButton>
+          <CustomButton onClick={continueClicked} classField={classes.continueButton} text="Continue" />
         </form>
       </div>
       {open && (

--- a/client/src/components/WaitingRoomUserList.js
+++ b/client/src/components/WaitingRoomUserList.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useHistory } from 'react-router';
-import { ContinueButton } from '../components/Buttons';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import Avatar from '@material-ui/core/Avatar';

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -9,7 +9,7 @@ import InterviewDifficultyMenu from './InterviewDifficultyMenu';
 
 import UserInformation from '../components/UserInformation';
 import { createInterview } from '../utils/apiFunctions';
-import { StartDashboardButton } from '../components/Buttons';
+import { CustomButton } from '../components/Buttons';
 import { Dialog, DialogTitle } from '@material-ui/core';
 
 const DashBoard = () => {
@@ -49,13 +49,7 @@ const DashBoard = () => {
   return (
     !state.loading && (
       <div className={classes.dashboardContainer}>
-        <StartDashboardButton
-          variant='outlined'
-          color='primary'
-          onClick={handleClickOpen}
-        >
-          START
-        </StartDashboardButton>
+        <CustomButton onClick={handleClickOpen} text='START' classField={classes.startDashboardButton} />
         <Dialog
           onClose={handleClose}
           aria-labelledby='simple-dialog-title'
@@ -72,7 +66,7 @@ const DashBoard = () => {
               selectedValue={selectedValue}
               handleChange={handleChange}
             />
-            <StartDashboardButton onClick={createInt}>Create</StartDashboardButton>
+            <CustomButton onClick={createInt} classField={classes.startDashboardButton} text='CREATE' />
           </div>
         </Dialog>
         <p className={classes.pastPracticesText}>Past Practice Interviews</p>

--- a/client/src/pages/Lobby.js
+++ b/client/src/pages/Lobby.js
@@ -6,7 +6,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Slide from '@material-ui/core/Slide';
-import { ContinueButton } from '../components/Buttons';
+import { CopyButton, CustomButton } from '../components/Buttons';
 import { TextField } from '@material-ui/core';
 import { store } from '../context/store';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
@@ -152,9 +152,9 @@ const Lobby = (props) => {
               onCopy={() => setCopied(true)}
               text={URL + history.location.pathname}
             >
-              <ContinueButton disabled={copied} color='primary'>
+              <CopyButton disabled={copied} color='primary'>
                 {!copied ? 'COPY' : 'COPIED!'}
-              </ContinueButton>
+              </CopyButton>
             </CopyToClipboard>
           </DialogActions>
           <DialogContent>
@@ -166,9 +166,7 @@ const Lobby = (props) => {
             handleClose={handleClose}
           />
           {!alert && creatorId && getUserLobbyCountFull() && (
-            <ContinueButton onClick={handleStartInterview} color='primary'>
-              Start
-            </ContinueButton>
+            <CustomButton onClick={handleStartInterview} classField={classes.continueButton} text='Start' color='primary' />
           )}
         </div>
       </Dialog>

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -455,7 +455,33 @@ export const useStyles = makeStyles((theme) => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center'
-  }
+  },
+  continueButton: {
+    background: colors.darkBlue,
+    color: 'white',
+    height: 48,
+    padding: '0 30px',
+    boxShadow: '0 3px 5px 2px rgba(125, 123, 135, .3)',
+    marginLeft: '10px',
+    borderRadius: 25,
+  },
+  redirectPageButton: {
+    color: colors.darkGray,
+    height: '5ch',
+    padding: '0 30px',
+    marginLeft: '10px',
+    borderRadius: 25,
+  },
+  startDashboardButton: {
+    borderRadius: 35,
+    height: 40,
+    width: 100,
+    backgroundColor: colors.darkBlue,
+    padding: '18px 36px',
+    fontSize: '18px',
+    color: 'white',
+    marginTop: '30px',
+  },
 }));
 
 export const GlobalCss = withStyles({


### PR DESCRIPTION
I slimmed down a few button components. These were the simple buttons that just had a class and text. Some buttons, like the copy button, next step button, and interview detail buttons had special cases where using a reusable button would break the app in one way or another so I left them untouched.