### PR TITLE
FS: Upcoming Interview Table - Dashboard

### DIFF
--- a/client/src/components/InterviewQuestionDetails.js
+++ b/client/src/components/InterviewQuestionDetails.js
@@ -1,87 +1,115 @@
-import React, { useState } from "react";
+import React, { Fragment, useState } from 'react';
 import { useStyles } from '../themes/theme';
-import { CustomButton, InterviewDetailButton } from './Buttons'
-import { generateKey } from '../utils/generateRandomKey'
+import { CustomButton, InterviewDetailButton } from './Buttons';
+import { generateKey } from '../utils/generateRandomKey';
 
 const InterviewQuestionDetails = ({ questions }) => {
   const classes = useStyles();
-
   const [questionHighlightToggle, setQuestionHighlightToggle] = useState({
     questionOne: true,
-    questionTwo: false
+    questionTwo: false,
   });
-
-  const questionSet = [...Object.values(questions)]
-  const [questionDisplayed, setQuestionDisplayed] = useState(0)
+  const questionSet = [...Object.values(questions)];
+  const [questionDisplayed, setQuestionDisplayed] = useState(0);
 
   const parsedQuestionDescription = (question) => {
     let mainDescriptionParsed = false;
     const lines = question.description.split('\n');
     const lineCount = lines.length;
     let codeBlockTexts = [];
-    return (
-      lines.map((line, index) => {
-        if (mainDescriptionWasParsed(line, index, lineCount)) {
-          mainDescriptionParsed = true;
-          const codeDiv = (
-            <>
-              {codeBlockTexts.length > 0 ?
-                <div className={classes.questionDescCodeBlock}>
-                  {codeBlockTexts.map(text => {
-                    return <p key={generateKey()}>{text}</p>
-                  })}
-                </div>
-                : <div key={generateKey()}></div>}
-              {line.startsWith("Example ") ? <p className={classes.questionDescExampleText}>{line}</p> : <></>}
-            </>
-          )
-          codeBlockTexts = [];
-          return codeDiv;
-        } else if (!mainDescriptionParsed) {
-          if (line.length !== 0) {
-            return <p className={classes.questionDescText}>{line}</p>
-          }
-          return <></>
-        } else {
-          codeBlockTexts.push(line);
+    return lines.map((line, index) => {
+      if (mainDescriptionWasParsed(line, index, lineCount)) {
+        mainDescriptionParsed = true;
+        const codeDiv = (
+          <Fragment key={index}>
+            {codeBlockTexts.length > 0 ? (
+              <div className={classes.questionDescCodeBlock}>
+                {codeBlockTexts.map((text) => {
+                  return <p key={generateKey()}>{text}</p>;
+                })}
+              </div>
+            ) : (
+                <div key={generateKey()}></div>
+              )}
+            {line.startsWith('Example ') ? (
+              <p key={index} className={classes.questionDescExampleText}>
+                {line}
+              </p>
+            ) : (
+                <Fragment key={index}></Fragment>
+              )}
+          </Fragment>
+        );
+        codeBlockTexts = [];
+        return codeDiv;
+      } else if (!mainDescriptionParsed) {
+        if (line.length !== 0) {
+          return (
+            <p key={index} className={classes.questionDescText}>
+              {line}
+            </p>
+          );
         }
-      })
-    );
-  }
+        return <Fragment key={index}></Fragment>;
+      } else {
+        codeBlockTexts.push(line);
+      }
+    });
+  };
 
   const mainDescriptionWasParsed = (line, index, lineCount) => {
-    return (line.startsWith("Example") || line.startsWith("Constraints:") || index === lineCount - 1)
-  }
+    return (
+      line.startsWith('Example') ||
+      line.startsWith('Constraints:') ||
+      index === lineCount - 1
+    );
+  };
 
-  const { questionOne, questionTwo } = questionHighlightToggle
+  const { questionOne, questionTwo } = questionHighlightToggle;
+
   return (
     <div className={classes.interviewDetailsContainer}>
       <div className={classes.questionAnswerButtonContainer}>
-        <div onClick={() => {
-          setQuestionHighlightToggle({ questionOne: true, questionTwo: false })
-          setQuestionDisplayed(0)
-        }}>
-          <InterviewDetailButton questionAnswerToggle={questionOne} text="Question #1" />
+        <div
+          onClick={() => {
+            setQuestionHighlightToggle({ questionOne: true, questionTwo: false });
+            setQuestionDisplayed(0);
+          }}
+        >
+          <InterviewDetailButton
+            questionAnswerToggle={questionOne}
+            text='Question #1'
+          />
         </div>
-        <div onClick={() => {
-          setQuestionHighlightToggle({ questionOne: false, questionTwo: true })
-          setQuestionDisplayed(1)
-        }}>
-          <InterviewDetailButton questionAnswerToggle={questionTwo} text="Question #2" />
+        <div
+          onClick={() => {
+            setQuestionHighlightToggle({ questionOne: false, questionTwo: true });
+            setQuestionDisplayed(1);
+          }}
+        >
+          <InterviewDetailButton
+            questionAnswerToggle={questionTwo}
+            text='Question #2'
+          />
         </div>
       </div>
       <div className={classes.questionDetailsContainer}>
-        <p className={classes.questionTopicText}>{questionSet[questionDisplayed].title}</p>
+        <p className={classes.questionTopicText}>
+          {questionSet[questionDisplayed].title}
+        </p>
         {parsedQuestionDescription(questionSet[questionDisplayed])}
         <div className={classes.answerButtonContainer}>
           <CustomButton
-            onClick={() => window.open(`${questionSet[questionDisplayed].url}/discuss`, "_blank")}
-            classField={classes.answerButton} text="View Answer"
+            onClick={() =>
+              window.open(`${questionSet[questionDisplayed].url}/discuss`, '_blank')
+            }
+            classField={classes.answerButton}
+            text='View Answer'
           />
         </div>
       </div>
     </div>
   );
-}
+};
 
 export default InterviewQuestionDetails;

--- a/client/src/components/UpcomingInterviewTable.js
+++ b/client/src/components/UpcomingInterviewTable.js
@@ -55,15 +55,21 @@ const UpcomingInterviewTable = ({ interviews }) => {
                 <div>{interview.created.time}</div>
               </TableCell>
               <TableCell align='center'>
-                <a className={classes.interviewQuestionTitle}>
-                  {interview.questionTitle}
-                </a>
+                {interview.questionTitle ?
+                  <a className={classes.interviewQuestionTitle}>
+                    {interview.questionTitle}
+                  </a> :
+                  <a className={classes.interviewNotStartedText}>
+                    (Interview not started)
+                  </a>}
               </TableCell>
               <TableCell align='right'>
                 <CustomButton classField={classes.interviewActionButton} text="Cancel" />
                 <CustomButton
-                  onClick={() => history.push({ pathname: `/interview/${interview.roomId}` })}
-                  classField={classes.interviewActionButton} text="Join"
+                  onClick={interview.questionTitle ?
+                    () => history.push({ pathname: `/interview/${interview.roomId}` }) :
+                    () => history.push({ pathname: `/lobby/${interview.roomId}` })}
+                  classField={classes.interviewActionButton} text={interview.questionTitle ? "Join" : 'Lobby'}
                 />
               </TableCell>
             </TableRow>

--- a/client/src/components/UpcomingInterviewTable.js
+++ b/client/src/components/UpcomingInterviewTable.js
@@ -1,31 +1,34 @@
-import React, { useState, useEffect, useContext } from 'react';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
+import React, { useState, useEffect } from 'react';
 import { useStyles } from '../themes/theme';
 import { getStandardTime } from '../utils/timeFunctions'
 import { CustomButton } from './Buttons'
 import { useHistory } from 'react-router';
 import { cancelInterview } from '../utils/apiFunctions';
-import { fetchInterviews } from '../utils/fetchInterviews';
-import { store } from '../context/store';
-import Typography from '@material-ui/core/Typography';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography
+} from '@material-ui/core';
 
 const UpcomingInterviewTable = ({ interviews }) => {
   const [upcomingInterviews, setUpcomingInterviews] = useState([]);
-  const { state } = useContext(store);
 
   useEffect(() => {
     createUpcomingInterviewsTable(interviews);
   }, []);
 
-  const cancelInterviewById = async (roomId) => {
-    await cancelInterview(roomId);
-    const interviews = await fetchInterviews(state.user._id, state.user);
-    createUpcomingInterviewsTable(interviews);
+  const cancelInterviewById = async (roomId, i) => {
+
+    const res = await cancelInterview(roomId);
+    if (res.status === 200) {
+      const interviewsCopy = [...upcomingInterviews];
+      interviewsCopy.splice(i, 1);
+      setUpcomingInterviews(interviewsCopy);
+    }
   }
 
   const createUpcomingInterviewsTable = (interviews) => {
@@ -76,7 +79,7 @@ const UpcomingInterviewTable = ({ interviews }) => {
               </TableCell>
               <TableCell align='center'>
                 {!interview.questionTitle &&
-                  <CustomButton onClick={() => cancelInterviewById(interview.roomId)} classField={classes.interviewActionButton} text="Cancel" />
+                  <CustomButton onClick={() => cancelInterviewById(interview.roomId, i)} classField={classes.interviewActionButton} text="Cancel" />
                 }
                 <CustomButton
                   onClick={interview.questionTitle ?

--- a/client/src/components/UpcomingInterviewTable.js
+++ b/client/src/components/UpcomingInterviewTable.js
@@ -9,6 +9,7 @@ import { useStyles } from '../themes/theme';
 import { getStandardTime } from '../utils/timeFunctions'
 import { CustomButton } from './Buttons'
 import { useHistory } from 'react-router';
+import { cancelInterview } from '../utils/apiFunctions';
 
 const UpcomingInterviewTable = ({ interviews }) => {
   const [upcomingInterviews, setUpcomingInterviews] = useState(null);
@@ -16,6 +17,11 @@ const UpcomingInterviewTable = ({ interviews }) => {
   useEffect(() => {
     createUpcomingInterviewsTable(interviews)
   }, []);
+
+  const cancelInterviewById = async (roomId) => {
+    await cancelInterview(roomId);
+    window.location.reload();
+  }
 
   const createUpcomingInterviewsTable = (interviews) => {
     const upcomingInterviews = []
@@ -64,7 +70,7 @@ const UpcomingInterviewTable = ({ interviews }) => {
                   </a>}
               </TableCell>
               <TableCell align='right'>
-                <CustomButton classField={classes.interviewActionButton} text="Cancel" />
+                <CustomButton onClick={() => cancelInterviewById(interview.roomId)} classField={classes.interviewActionButton} text="Cancel" />
                 <CustomButton
                   onClick={interview.questionTitle ?
                     () => history.push({ pathname: `/interview/${interview.roomId}` }) :

--- a/client/src/components/UpcomingInterviewTable.js
+++ b/client/src/components/UpcomingInterviewTable.js
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import { useStyles } from '../themes/theme';
+import { getStandardTime } from '../utils/timeFunctions'
+import { CustomButton } from './Buttons'
+import { useHistory } from 'react-router';
+
+const UpcomingInterviewTable = ({ interviews }) => {
+  const [upcomingInterviews, setUpcomingInterviews] = useState(null);
+
+  useEffect(() => {
+    createUpcomingInterviewsTable(interviews)
+  }, []);
+
+  const createUpcomingInterviewsTable = (interviews) => {
+    const upcomingInterviews = []
+    for (const interview of interviews) {
+      const created = getStandardTime(interview.createdAt)
+      const questionTitle = interview.questionTitle
+      const roomId = interview.interviewId
+      upcomingInterviews.push({ created, questionTitle, roomId })
+    }
+    setUpcomingInterviews(upcomingInterviews)
+  }
+
+  const classes = useStyles();
+  const history = useHistory();
+
+  return (
+    <TableContainer>
+      <Table className={classes.interviewTable} aria-label='simple table'>
+        <TableHead className={classes.interviewTableHeader}>
+          <TableRow>
+            <TableCell className={classes.headerFont} align='left'>
+              Created
+            </TableCell>
+            <TableCell className={classes.headerFont} align='center'>
+              Your Question
+            </TableCell>
+            <TableCell className={classes.headerFont} align='center'>
+              Action
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {upcomingInterviews && upcomingInterviews.map((interview, i) => (
+            <TableRow key={i}>
+              <TableCell component='th' scope='row'>
+                <div>{interview.created.date}</div>
+                <div>{interview.created.time}</div>
+              </TableCell>
+              <TableCell align='center'>
+                <a className={classes.interviewQuestionTitle}>
+                  {interview.questionTitle}
+                </a>
+              </TableCell>
+              <TableCell align='right'>
+                <CustomButton classField={classes.interviewActionButton} text="Cancel" />
+                <CustomButton
+                  onClick={() => history.push({ pathname: `/interview/${interview.roomId}` })}
+                  classField={classes.interviewActionButton} text="Join"
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default UpcomingInterviewTable;

--- a/client/src/components/UpcomingInterviewTable.js
+++ b/client/src/components/UpcomingInterviewTable.js
@@ -69,8 +69,10 @@ const UpcomingInterviewTable = ({ interviews }) => {
                     (Interview not started)
                   </a>}
               </TableCell>
-              <TableCell align='right'>
-                <CustomButton onClick={() => cancelInterviewById(interview.roomId)} classField={classes.interviewActionButton} text="Cancel" />
+              <TableCell align='center'>
+                {!interview.questionTitle &&
+                  <CustomButton onClick={() => cancelInterviewById(interview.roomId)} classField={classes.interviewActionButton} text="Cancel" />
+                }
                 <CustomButton
                   onClick={interview.questionTitle ?
                     () => history.push({ pathname: `/interview/${interview.roomId}` }) :

--- a/client/src/components/UpcomingInterviewTable.js
+++ b/client/src/components/UpcomingInterviewTable.js
@@ -12,6 +12,7 @@ import { useHistory } from 'react-router';
 import { cancelInterview } from '../utils/apiFunctions';
 import { fetchInterviews } from '../utils/fetchInterviews';
 import { store } from '../context/store';
+import Typography from '@material-ui/core/Typography';
 
 const UpcomingInterviewTable = ({ interviews }) => {
   const [upcomingInterviews, setUpcomingInterviews] = useState([]);
@@ -66,12 +67,12 @@ const UpcomingInterviewTable = ({ interviews }) => {
               </TableCell>
               <TableCell align='center'>
                 {interview.questionTitle ?
-                  <a className={classes.interviewQuestionTitle}>
+                  <Typography className={classes.interviewQuestionTitle}>
                     {interview.questionTitle}
-                  </a> :
-                  <a className={classes.interviewNotStartedText}>
+                  </Typography> :
+                  <Typography className={classes.interviewNotStartedText}>
                     (Interview not started)
-                  </a>}
+                  </Typography>}
               </TableCell>
               <TableCell align='center'>
                 {!interview.questionTitle &&

--- a/client/src/components/UpcomingInterviewTable.js
+++ b/client/src/components/UpcomingInterviewTable.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
@@ -10,28 +10,32 @@ import { getStandardTime } from '../utils/timeFunctions'
 import { CustomButton } from './Buttons'
 import { useHistory } from 'react-router';
 import { cancelInterview } from '../utils/apiFunctions';
+import { fetchInterviews } from '../utils/fetchInterviews';
+import { store } from '../context/store';
 
 const UpcomingInterviewTable = ({ interviews }) => {
-  const [upcomingInterviews, setUpcomingInterviews] = useState(null);
+  const [upcomingInterviews, setUpcomingInterviews] = useState([]);
+  const { state } = useContext(store);
 
   useEffect(() => {
-    createUpcomingInterviewsTable(interviews)
+    createUpcomingInterviewsTable(interviews);
   }, []);
 
   const cancelInterviewById = async (roomId) => {
     await cancelInterview(roomId);
-    window.location.reload();
+    const interviews = await fetchInterviews(state.user._id, state.user);
+    createUpcomingInterviewsTable(interviews);
   }
 
   const createUpcomingInterviewsTable = (interviews) => {
-    const upcomingInterviews = []
+    const upcomingInterviews = [];
     for (const interview of interviews) {
-      const created = getStandardTime(interview.createdAt)
-      const questionTitle = interview.questionTitle
-      const roomId = interview.interviewId
-      upcomingInterviews.push({ created, questionTitle, roomId })
+      const created = getStandardTime(interview.createdAt);
+      const questionTitle = interview.questionTitle;
+      const roomId = interview.interviewId;
+      upcomingInterviews.push({ created, questionTitle, roomId });
     }
-    setUpcomingInterviews(upcomingInterviews)
+    setUpcomingInterviews(upcomingInterviews);
   }
 
   const classes = useStyles();

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -41,7 +41,14 @@ const DashBoard = () => {
             lastName: u.data.user.lastName,
             questionTitle: q.data.title,
             questionDescription: q.data.description
-          })
+          });
+        } else {
+          if (user.user === userId) {
+            interviews.push({
+              createdAt: interview.createdAt,
+              interviewId: interview._id,
+            });
+          }
         }
       }
     }
@@ -53,7 +60,6 @@ const DashBoard = () => {
   }
 
   useEffect(() => {
-    console.log(state)
     fetchInterviews(state.user._id)
   }, []);
 

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 
 import { useStyles } from '../themes/theme';
 import PastInterviewTable from '../components/PastInterviewTable';
+import UpcomingInterviewTable from '../components/UpcomingInterviewTable'
 import { store } from '../context/store';
 
 import { useHistory } from 'react-router';
@@ -9,7 +10,7 @@ import InterviewDifficultyMenu from './InterviewDifficultyMenu';
 
 import UserInformation from '../components/UserInformation';
 import { createInterview, getQuestion, getUser, getUserInterviews } from '../utils/apiFunctions';
-import { StartDashboardButton } from '../components/Buttons';
+import { CustomButton } from '../components/Buttons';
 import { Dialog, DialogTitle } from '@material-ui/core';
 
 const DashBoard = () => {
@@ -33,6 +34,7 @@ const DashBoard = () => {
           const q = await getQuestion(user.question);
 
           interviews.push({
+            createdAt: interview.createdAt,
             interviewId: interview._id,
             userId: u.data.user._id,
             firstName: u.data.user.firstName,
@@ -105,6 +107,8 @@ const DashBoard = () => {
             <CustomButton onClick={createInt} classField={classes.startDashboardButton} text='CREATE' />
           </div>
         </Dialog>
+        <p className={classes.pastPracticesText}>Upcoming Practice Interviews</p>
+        <UpcomingInterviewTable interviews={pageData.interviews} />
         <p className={classes.pastPracticesText}>Past Practice Interviews</p>
         <PastInterviewTable />
       </div>

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -23,7 +23,7 @@ const DashBoard = () => {
   });
 
   const getInterviews = async () => {
-    const interviews = await fetchInterviews(state.user._id, state.user)
+    const interviews = await fetchInterviews(state.user._id)
 
     setPageData({
       pageLoaded: true,

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -1,13 +1,10 @@
 import React, { useContext, useEffect, useState } from 'react';
-
 import { useStyles } from '../themes/theme';
 import PastInterviewTable from '../components/PastInterviewTable';
 import UpcomingInterviewTable from '../components/UpcomingInterviewTable'
 import { store } from '../context/store';
-
 import { useHistory } from 'react-router';
 import InterviewDifficultyMenu from './InterviewDifficultyMenu';
-
 import UserInformation from '../components/UserInformation';
 import { createInterview, getQuestion, getUser, getUserInterviews } from '../utils/apiFunctions';
 import { CustomButton } from '../components/Buttons';

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -29,26 +29,27 @@ const DashBoard = () => {
     const interviews = [];
     for (const interview of userInterviews) {
       for (const user of interview.users) {
-        if (user.user === userId && user.question !== undefined) {
-          const u = await getUser(user);
-          const q = await getQuestion(user.question);
+        if (user.user === userId) {
+          const {
+            _id: userId,
+            firstName,
+            lastName
+          } = (await getUser(user)).data.user;
+
+          const {
+            title: questionTitle,
+            description: questionDescription
+          } = user.question ? (await getQuestion(user.question)).data : {};
 
           interviews.push({
             createdAt: interview.createdAt,
             interviewId: interview._id,
-            userId: u.data.user._id,
-            firstName: u.data.user.firstName,
-            lastName: u.data.user.lastName,
-            questionTitle: q.data.title,
-            questionDescription: q.data.description
+            userId,
+            firstName,
+            lastName,
+            questionTitle,
+            questionDescription,
           });
-        } else {
-          if (user.user === userId) {
-            interviews.push({
-              createdAt: interview.createdAt,
-              interviewId: interview._id,
-            });
-          }
         }
       }
     }

--- a/client/src/pages/DashBoard.js
+++ b/client/src/pages/DashBoard.js
@@ -6,9 +6,10 @@ import { store } from '../context/store';
 import { useHistory } from 'react-router';
 import InterviewDifficultyMenu from './InterviewDifficultyMenu';
 import UserInformation from '../components/UserInformation';
-import { createInterview, getQuestion, getUser, getUserInterviews } from '../utils/apiFunctions';
+import { createInterview } from '../utils/apiFunctions';
 import { CustomButton } from '../components/Buttons';
 import { Dialog, DialogTitle } from '@material-ui/core';
+import { fetchInterviews } from '../utils/fetchInterviews';
 
 const DashBoard = () => {
   const classes = useStyles();
@@ -21,35 +22,8 @@ const DashBoard = () => {
     interviews: null
   });
 
-  const fetchInterviews = async (userId) => {
-    const { data: userInterviews } = await getUserInterviews(userId);
-    const interviews = [];
-    for (const interview of userInterviews) {
-      for (const user of interview.users) {
-        if (user.user === userId) {
-          const {
-            _id: userId,
-            firstName,
-            lastName
-          } = (await getUser(user)).data.user;
-
-          const {
-            title: questionTitle,
-            description: questionDescription
-          } = user.question ? (await getQuestion(user.question)).data : {};
-
-          interviews.push({
-            createdAt: interview.createdAt,
-            interviewId: interview._id,
-            userId,
-            firstName,
-            lastName,
-            questionTitle,
-            questionDescription,
-          });
-        }
-      }
-    }
+  const getInterviews = async () => {
+    const interviews = await fetchInterviews(state.user._id, state.user)
 
     setPageData({
       pageLoaded: true,
@@ -58,7 +32,7 @@ const DashBoard = () => {
   }
 
   useEffect(() => {
-    fetchInterviews(state.user._id)
+    getInterviews()
   }, []);
 
   const handleClickOpen = () => {

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -482,6 +482,21 @@ export const useStyles = makeStyles((theme) => ({
     color: 'white',
     marginTop: '30px',
   },
+  interviewActionButton: {
+    borderRadius: 35,
+    height: 20,
+    width: 100,
+    color: colors.darkGray,
+    padding: '18px 36px',
+    fontSize: '18px',
+    fontWeight: 'bold',
+    margin: '5px'
+  },
+  interviewQuestionTitle: {
+    color: colors.darkBlue,
+    fontSize: '16px',
+    fontWeight: 'bold',
+  }
 }));
 
 export const GlobalCss = withStyles({

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -496,6 +496,11 @@ export const useStyles = makeStyles((theme) => ({
     color: colors.darkBlue,
     fontSize: '16px',
     fontWeight: 'bold',
+  },
+  interviewNotStartedText: {
+    color: 'black',
+    fontSize: '16px',
+    fontWeight: 'bold',
   }
 }));
 

--- a/client/src/utils/apiFunctions.js
+++ b/client/src/utils/apiFunctions.js
@@ -47,3 +47,7 @@ export const getQuestion = (questionId) => {
 export const getUserInterviews = (userId) => {
   return api.get(`/interviews/user/${userId}`);
 }
+
+export const cancelInterview = (userId) => {
+  return api.post(`/interviews/${userId}/cancel`);
+}

--- a/client/src/utils/apiFunctions.js
+++ b/client/src/utils/apiFunctions.js
@@ -37,9 +37,13 @@ export const logoutUser = () => {
 };
 
 export const getInterview = (roomId) => {
-  return api.get(`/interviews/${roomId}`)
+  return api.get(`/interviews/${roomId}`);
 };
 
 export const getQuestion = (questionId) => {
-  return api.get(`/questions/${questionId}`)
+  return api.get(`/questions/${questionId}`);
 };
+
+export const getUserInterviews = (userId) => {
+  return api.get(`/interviews/user/${userId}`);
+}

--- a/client/src/utils/fetchInterviews.js
+++ b/client/src/utils/fetchInterviews.js
@@ -1,0 +1,34 @@
+import { getUserInterviews, getQuestion } from './apiFunctions'
+
+export const fetchInterviews = async (userId, userState) => {
+  const { data: userInterviews } = await getUserInterviews(userId);
+  const interviews = [];
+  for (const interview of userInterviews) {
+    for (const user of interview.users) {
+      if (user.user === userId) {
+        const {
+          _id: userId,
+          firstName,
+          lastName
+        } = userState;
+
+        const {
+          title: questionTitle,
+          description: questionDescription
+        } = user.question ? (await getQuestion(user.question)).data : {};
+
+        interviews.push({
+          createdAt: interview.createdAt,
+          interviewId: interview._id,
+          userId,
+          firstName,
+          lastName,
+          questionTitle,
+          questionDescription,
+        });
+      }
+    }
+  }
+
+  return interviews;
+};

--- a/client/src/utils/fetchInterviews.js
+++ b/client/src/utils/fetchInterviews.js
@@ -1,17 +1,11 @@
 import { getUserInterviews, getQuestion } from './apiFunctions'
 
-export const fetchInterviews = async (userId, userState) => {
+export const fetchInterviews = async (userId) => {
   const { data: userInterviews } = await getUserInterviews(userId);
   const interviews = [];
   for (const interview of userInterviews) {
     for (const user of interview.users) {
       if (user.user === userId) {
-        const {
-          _id: userId,
-          firstName,
-          lastName
-        } = userState;
-
         const {
           title: questionTitle,
           description: questionDescription
@@ -20,9 +14,6 @@ export const fetchInterviews = async (userId, userState) => {
         interviews.push({
           createdAt: interview.createdAt,
           interviewId: interview._id,
-          userId,
-          firstName,
-          lastName,
           questionTitle,
           questionDescription,
         });

--- a/client/src/utils/timeFunctions.js
+++ b/client/src/utils/timeFunctions.js
@@ -1,0 +1,12 @@
+import moment from 'moment'
+
+export const getStandardTime = (time) => {
+  const epochTime = time;
+  const date = new Date(0);
+  date.setUTCSeconds(epochTime);
+
+  return {
+    date: date.toDateString(),
+    time: moment(date.toTimeString().split(' ')[0], 'HH:mm:ss').format('h:mm: A')
+  }
+}

--- a/server/controllers/interviewController.js
+++ b/server/controllers/interviewController.js
@@ -48,10 +48,18 @@ const startInterview = async (req, res) => {
 
   res.json(interview)
 }
+
+const getInterviewsByUserId = async (req, res) => {
+  const email = req.user.email;
+  const interviews = (await User.findOne({ email }).populate('interviews')).interviews;
+  res.json(interviews);
+}
+
 module.exports = {
   cInterview,
   endInterview,
   addUser,
   getInterview,
-  startInterview
+  startInterview,
+  getInterviewsByUserId
 };

--- a/server/controllers/interviewController.js
+++ b/server/controllers/interviewController.js
@@ -55,11 +55,18 @@ const getInterviewsByUserId = async (req, res) => {
   res.json(interviews);
 }
 
+const cancelInterviewById = async (req, res) => {
+  const { id } = req.params
+  const interviews = await Interview.findByIdAndDelete(id)
+  res.json(interviews);
+}
+
 module.exports = {
   cInterview,
   endInterview,
   addUser,
   getInterview,
   startInterview,
-  getInterviewsByUserId
+  getInterviewsByUserId,
+  cancelInterviewById
 };

--- a/server/routes/interviews.js
+++ b/server/routes/interviews.js
@@ -47,4 +47,9 @@ router.post(
   interviewController.startInterview
 );
 
+router.post(
+  '/:id/cancel',
+  passport.authenticate('jwt', { session: false }),
+  interviewController.cancelInterviewById
+);
 module.exports = router;

--- a/server/routes/interviews.js
+++ b/server/routes/interviews.js
@@ -35,6 +35,12 @@ router.get(
   interviewController.getInterview
 );
 
+router.get(
+  '/user/:userId',
+  passport.authenticate('jwt', { session: false }),
+  interviewController.getInterviewsByUserId
+);
+
 router.post(
   '/:id/start',
   passport.authenticate('jwt', { session: false }),


### PR DESCRIPTION
I implemented the upcoming interview table. When the dashboard loads, it will fetch all the current interviews of the authenticated user and display them on a table. For interviews that started but not completed, you can click cancel(delete the interview from db) or join (redirect user to interview room). For interviews that were created but not started, you can cancel the room or click lobby which will redirect the user to the waiting room.

<img width="976" alt="Screen Shot 2020-11-28 at 1 40 08 PM" src="https://user-images.githubusercontent.com/61174647/100523550-3f726000-317f-11eb-93ea-5dbd0fc8c044.png">

//TODO: Past interview table (will finish once feedback dialog/exit interview logic has been pushed up).